### PR TITLE
Pass get URLs through a filter

### DIFF
--- a/inc/class-plugin.php
+++ b/inc/class-plugin.php
@@ -28,7 +28,7 @@ class Plugin {
 	 * @return Array
 	 */
 	public function get_base_urls() {
-		return get_option( 'static_mirror_base_urls', array( get_option( 'siteurl' ) ) );
+		return apply_filters( 'static_mirror_base_urls', get_option( 'static_mirror_base_urls', array( get_option( 'siteurl' ) ) ) );
 	}
 
 	/**


### PR DESCRIPTION
Issue on the staging site: behind .htaccess. 

The easiest fix I could think of was to pass basic auth details as part of the URL, and thought having a filter here would be useful for stuff like this.

I actually fixed the issue for now by updating the option using wp-cli.
