### PR TITLE
method bulk_actions not compatable with parent class method 

### DIFF
--- a/inc/class-admin-list-table.php
+++ b/inc/class-admin-list-table.php
@@ -80,8 +80,7 @@ class List_Table extends \WP_Posts_List_Table {
 		$this->display_tablenav( 'bottom' );
 	}
 
-	public function bulk_actions() {
-
+	public function bulk_actions( $which = '' ) {
 	}
 
 	/**


### PR DESCRIPTION
(fix strict standards notice)

When running WordPress trunk I get a strict standards notice caused by static-mirror plugin.

This is because of the changes made here: https://github.com/WordPress/WordPress/commit/704a4c48036dd25a5f978b33b68149b8efb10b30 
