### PR TITLE
Load jQuery UI Datepicker CSS through HTTPS.

### DIFF
--- a/inc/class-admin-list-table.php
+++ b/inc/class-admin-list-table.php
@@ -17,7 +17,7 @@ class List_Table extends \WP_Posts_List_Table {
 		wp_enqueue_script( 'static-mirror-jquery-date-picker', SM_PLUGIN_URL . 'js/admin.js' );
 
 		// CSS
-		wp_enqueue_style( 'jquery-ui-datepicker', 'http://ajax.googleapis.com/ajax/libs/jqueryui/1.8.18/themes/smoothness/jquery-ui.css' );
+		wp_enqueue_style( 'jquery-ui-datepicker', 'https://ajax.googleapis.com/ajax/libs/jqueryui/1.8.18/themes/smoothness/jquery-ui.css' );
 	}
 
 	public function prepare_items() {


### PR DESCRIPTION
This prevents the browser from blocking this stylesheet due to it being loaded over an insecure protocol.