### PR TITLE
Prevent notice in custom `WP_Posts_List_Table`

### DIFF
--- a/inc/class-admin-list-table.php
+++ b/inc/class-admin-list-table.php
@@ -243,7 +243,7 @@ class List_Table extends \WP_Posts_List_Table {
 			'info' => 'Snapshot',
 		);
 
-		$this->_column_headers = array( $columns, array(), array() );
+		$this->_column_headers = array( $columns, array(), array(), '' );
 
 		return $this->_column_headers;
 	}


### PR DESCRIPTION
WordPress 4.3 we added a fourth argument for primary column in the `get_column_info()` method, so we need to set this in the array to prevent a notice.