### PR TITLE
Ensure cron job failures are reported as such.

### DIFF
--- a/inc/class-plugin.php
+++ b/inc/class-plugin.php
@@ -276,7 +276,7 @@ class Plugin {
 
 	public function complete_mirror( Array $changelog ) {
 
-		$this->mirror( $changelog, $this->get_base_urls(), true );
+		return $this->mirror( $changelog, $this->get_base_urls(), true );
 	}
 
 	public function mirror( Array $changelog, Array $urls, $recursive = false ) {


### PR DESCRIPTION
The `complete_mirror` method did not return the results of the `mirror` method. This prevented the `mirror_on_cron` method from correctly reporting failures.